### PR TITLE
Add xrepo_package function to use xrepo packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,140 @@
 # xrepo-cmake
-CMake wrapper for Xrepo C and C++ package manager
+
+CMake wrapper for [Xrepo](https://xrepo.xmake.io/) C and C++ package manager.
+
+This allows using CMake to build your project, while using Xrepo to manage
+dependent packages. This project is partially inspired by
+[cmake-conan](https://github.com/conan-io/cmake-conan).
+
+Example use cases for this project:
+
+- Existing CMake projects which want to use Xrepo to manage packages.
+- New projects which have to use CMake, but want to use Xrepo to manage
+  packages.
+
+# Usage
+
+[`xrepo.cmake`](./xrepo.cmake) provides `xrepo_package` function to manage
+packages.
+
+```cmake
+xrepo_package(
+    "foo 1.2.3"
+    [CONFIGS feature1=true,feature2=false]
+    [MODE debug|release]
+    [DIRECTORY_SCOPE]
+)
+```
+
+Some of the function arguments correspond directly to Xrepo command options.
+
+After calling `xrepo_pacakge(foo)`, there are two ways to use `foo` package:
+
+- Call `find_package(foo)` if package provides cmake modules to find it
+  - Refer to CMake [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) documentation for more details
+- If the package does not provide cmake modules, `foo_INCLUDE_DIR` and
+  `foo_LINK_DIR` variables will be set to the package include and library paths.
+  Use these variables to setup include and library paths in your CMake code.
+  - If `DIRECTORY_SCOPE` is specified, `xrepo_package` will run following code
+    (so that user only need to specify lib name in `target_link_libraries`)
+  ```cmake
+    include_directories(foo_INCLUDE_DIR)
+    link_directories(foo_LINK_DIR)
+  ```
+    
+Here's an example `CMakeLists.txt` that uses `gflags` package version 2.2.2
+managed by Xrepo.
+
+```cmake
+cmake_minimum_required(VERSION 3.13.0)
+
+project(foo)
+
+# Download xrepo.cmake if not exists in build directory.
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/xrepo.cmake")
+    message(STATUS "Downloading xrepo.cmake from https://github.com/xmake-io/xrepo-cmake/")
+    file(DOWNLOAD "https://raw.githubusercontent.com/xmake-io/xrepo-cmake/main/xrepo.cmake"
+                  "${CMAKE_BINARY_DIR}/xrepo.cmake"
+                  TLS_VERIFY ON)
+endif()
+
+# Include xrepo.cmake so we can use xrepo_package function.
+include(${CMAKE_BINARY_DIR}/xrepo.cmake)
+
+# Call `xrepo_package` function to use gflags 2.2.2 with specific configs.
+xrepo_pacakge("gflags 2.2.2" CONFIGS "shared=true,mt=true")
+
+# `xrepo_package` sets `gflags_DIR` variable in parent scope because gflags
+# provides cmake modules. So we can now call `find_pacakge` to find gflags
+# package.
+find_package(gflags CONFIG COMPONENTS shared)
+```
+
+# How does it work?
+
+[`xrepo.cmake`](./xrepo.cmake) module basically does the following tasks:
+
+- Call `xrepo install` to ensure specific package is installed.
+- Call `xrepo fetch` to get package information and setup various variables for
+  using the installed package in CMake.
+
+The following section is a short introduction to using Xrepo. It helps to
+understand how `xrepo.cmake` works and how to specify some of the options in
+`xrepo_package`.
+
+## Xrepo workflow
+
+Assume [Xmake](https://github.com/xmake-io/xmake/) is installed.
+
+Suppose we want to use `gflags` packages.
+
+First, search for `gflags` package in Xrepo.
+
+```
+$ xrepo search gflags
+The package names:
+    gflags:
+      -> gflags-v2.2.2: The gflags package contains a C++ library that implements commandline flags processing. (in builtin-repo)
+```
+
+It's already in Xrepo, so we can use it. If it's not in Xrepo, we can create it in
+[self-built repositories](https://xrepo.xmake.io/#/getting_started?id=suppory-distributed-repository).
+
+Let's see what configs are available for the package before using it:
+
+```
+$ xrepo info gflags
+...
+      -> configs:
+         -> mt: Build the multi-threaded gflags library. (default: false)
+      -> configs (builtin):
+         -> debug: Enable debug symbols. (default: false)
+         -> shared: Build shared library. (default: false)
+         -> pic: Enable the position independent code. (default: true)
+...
+```
+
+Suppose we want to use multi-threaded gflags shared library. We can install the package with following command:
+
+```
+xrepo install --mode=release --configs='mt=true,shared=true' 'gflags 2.2.2'
+```
+
+Only the first call to the above command will compile and install the package. So `xrepo_package` always calls the above command to ensure the package is installed.
+
+After package installation, because we are using CMake instead of Xmake, we have
+to get package installation information by ourself. `xrepo fetch` command does
+exactly this:
+
+```
+xrepo fetch --mode=release --configs='mt=true,shared=true' 'gflags 2.2.2'
+```
+
+The above command will print out package's include, library directory along with
+other information. `xrepo_package` uses these information to setup variables to use
+the specified package.
+
+Currently, `xrepo_package` uses only the `--cflags` option to get package
+include directory. Library and cmake module directory are infered from that
+directory, so it maybe unreliable to detect the correct paths. We will improve
+this in the future.

--- a/xrepo.cmake
+++ b/xrepo.cmake
@@ -1,0 +1,115 @@
+# xrepo_package:
+#
+# Parameters:
+#     package_spec: required
+#         The package name and version recognized by xrepo.
+#     CONFIGS: optional
+#         Run `xrepo info <package>` to see what configs are available.
+#     MODE: optional
+#         If not specified: mode is set to "debug" only when $CMAKE_BUILD_TYPE
+#         is Debug. Otherwise mode is `release`.
+#     DIRECTORY_SCOPE: optional
+#         If specified, setup include and link directories for the package in
+#         CMake directory scope. CMake code in `add_subdirectory` can also use
+#         the package directly.
+#
+# Example:
+#
+#     xrepo_package(
+#         "foo 1.2.3"
+#         [CONFIGS feature1=true,feature2=false]
+#         [MODE debug|release]
+#         [DIRECTORY_SCOPE]
+#     )
+#
+# `xrepo_package` does the following tasks for the above call:
+#
+# 1. Ensure specified package `foo` version 1.2.3 with given config is installed.
+# 2. Set variable `foo_INCLUDE_DIR` and `foo_LINK_DIR` to header and library
+#    path.
+#    -  Use these variables in `target_include_directories` and
+#      `target_link_directories` to use the pacakge.
+#    - User should figure out what library to use for `target_link_libraries`.
+#    - If `DIRECTORY_SCOPE` is specified, execute following code so the package
+#      can be used in cmake's direcotry scope:
+#          include_directories(foo_INCLUDE_DIR)
+#          link_directories(foo_LINK_DIR)
+# 3. If package provides cmake modules under `foo_LINK_DIR/cmake/package`,
+#    set `foo_DIR` to the module directory so that `find_package(foo)`
+#    can be used.
+function(xrepo_package package)
+    find_program(xrepo_cmd xrepo)
+    if(NOT xrepo_cmd)
+        message(FATAL_ERROR "xrepo executable not found!")
+    endif()
+
+    set(options DIRECTORY_SCOPE)
+    cmake_parse_arguments(ARG "${options}" "${one_value_args}" "" ${ARGN})
+
+    if(DEFINED ARG_CONFIGS)
+        set(configs "--configs=${ARG_CONFIGS}")
+    else()
+        set(configs "")
+    endif()
+
+    if(DEFINED ARG_MODE)
+        _validate_mode(${ARG_MODE})
+        set(mode "--mode=${ARG_MODE}")
+    else()
+        string(TOLOWER ${CMAKE_BUILD_TYPE} _cmake_build_type)
+        if(_cmake_build_type STREQUAL "debug")
+            set(mode "--mode=debug")
+        else()
+            set(mode "--mode=release")
+        endif()
+    endif()
+
+    message(STATUS "xrepo install ${mode} ${configs} ${package}")
+    execute_process(COMMAND ${xrepo_cmd} install --yes --quiet ${mode} ${configs} ${package}
+                    RESULT_VARIABLE exit_code)
+    if(NOT "${exit_code}" STREQUAL "0")
+        message(FATAL_ERROR "xrepo install failed, exit code: ${exit_code}")
+    endif()
+
+    # Set up variables to use pacakge.
+    # Use cflags to get path to headers. Then we look for lib dir based on headers dir.
+    # TODO Find more reliable way to setup for using a package. Maybe change
+    # xrepo to support generating cmake find package related code.
+    execute_process(COMMAND ${xrepo_cmd} fetch --cflags ${mode} ${configs} ${package}
+                    OUTPUT_VARIABLE cflags_output
+                    RESULT_VARIABLE exit_code)
+    if(NOT "${exit_code}" STREQUAL "0")
+        message(FATAL_ERROR "xrepo fetch failed, exit code: ${exit_code}")
+    endif()
+
+    string(REGEX REPLACE "-I(.*)/include.*" "\\1" install_dir ${cflags_output})
+    string(REGEX REPLACE "([^ ]+).*" "\\1" package_name ${package})
+    message(STATUS "xrepo ${package_name} install_dir: ${install_dir}")
+
+    set(${package_name}_INCLUDE_DIR ${install_dir}/include PARENT_SCOPE)
+
+    if(EXISTS ${install_dir}/lib)
+        set(${package_name}_LINK_DIR ${install_dir}/lib PARENT_SCOPE)
+    endif()
+    if(EXISTS ${install_dir}/lib/cmake/${package_name})
+        set(${package_name}_DIR ${install_dir}/lib/cmake/${package_name} PARENT_SCOPE)
+    endif()
+
+    if(_XREPO_DIRECTORY_SCOPE)
+        message(STATUS "set ${package} include dir")
+        include_directories(${${package_name}_INCLUDE_DIR})
+        if(DEFINED ${package_name}_LINK_DIR)
+            message(STATUS "set ${package} link dir")
+            include_directories(${${package_name}_LINK_DIR})
+        endif()
+    endif()
+endfunction()
+
+function(_validate_mode mode)
+    string(TOLOWER ${mode} _mode)
+    if(NOT ((_mode STREQUAL "debug") OR (_mode STREQUAL "release")))
+        message(FATAL_ERROR
+            "xrepo_package invalid MODE: ${mode}, valid values: debug, release")
+    endif()
+endfunction()
+


### PR DESCRIPTION
README should contain enough detail about how the `xrepo_package`  function work.

Relying on `xrepo fetch --clfags` and then infer library and cmake modules path is not reliable, but at least make this project basically usable for now.

There are two ways for future improvement IMHO:

1. Let `xrepo` generate cmake code that can be include in CMakeLists.txt to use the installed package
   - This ties Xrepo to CMake, but would be easier to include dependent packages
2. Let `xrepo fetch` output JSON so we can rely on CMake 3.19 to parse JSON output for more reliable path detection

Please tell me what's your thought on this.

Featurewise, I want support specifing compiler for `xrepo_pacakge`. As I'm still new to xmake/xrepo and is experimenting on this, I'll try this in the future.