### PR TITLE
Do not pass --mode=debug according to CMAKE_BUILD_TYPE.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 include(${CMAKE_BINARY_DIR}/xrepo.cmake)
 
 # Call `xrepo_package` function to use default pcre2
-xrepo_package("pcre2")
+xrepo_package("pcre2" MODE debug)
 
 # Call `xrepo_package` function to use gflags 2.2.2 with specific configs.
 xrepo_package("gflags 2.2.2"

--- a/scripts/test-unix.sh
+++ b/scripts/test-unix.sh
@@ -8,6 +8,7 @@ rm -rf CMakeCache.txt CMakeFiles/ cmake_install.cmake
 # First build.
 output=cmake.log.0
 cmake -DXREPO_PACKAGE_VERBOSE=ON example | tee $output
+grep -E 'mode=debug pcre2' $output
 grep -E "pcre2_INCLUDE_DIRS" $output
 grep -E "pcre2_LIBRARY_DIRS" $output
 grep -E "pcre2_LIBRARIES" $output

--- a/xrepo.cmake
+++ b/xrepo.cmake
@@ -31,9 +31,8 @@ set(XREPO_XMAKEFILE "" CACHE STRING "Xmake script file of Xrepo package")
 #          variables. Also add all dependent libraries' install dir to
 #          CMAKE_PREFIX_PATH.
 #      MODE: optional, debug|release
-#          If not specified: mode is set to "debug" only when $CMAKE_BUILD_TYPE
-#          is Debug. Otherwise mode is `release`.
-#          Note: setting `MODE debug` has the same effect as `CONFIGS debug=true`.
+#          Pass `--mode` option to xrepo install command. If not specified,
+#          `--mode` option is not passed.
 #      OUTPUT: optional, verbose|diagnosis|quiet
 #          Control output for xrepo install command.
 #      DIRECTORY_SCOPE: optional
@@ -278,15 +277,7 @@ function(xrepo_package package)
     endif()
 
     if(DEFINED ARG_MODE)
-        _validate_mode(${ARG_MODE})
         set(mode "--mode=${ARG_MODE}")
-    else()
-        string(TOLOWER "${CMAKE_BUILD_TYPE}" _cmake_build_type)
-        if(_cmake_build_type STREQUAL "debug")
-            set(mode "--mode=debug")
-        else()
-            set(mode "--mode=release")
-        endif()
     endif()
 
     if(XREPO_PACKAGE_VERBOSE)
@@ -450,13 +441,6 @@ macro(_xrepo_finish_package_setup package_name)
 
     set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
 endmacro()
-
-function(_validate_mode mode)
-    string(TOLOWER ${mode} _mode)
-    if(NOT ((_mode STREQUAL "debug") OR (_mode STREQUAL "release")))
-        message(FATAL_ERROR "xrepo_package invalid MODE: ${mode}, valid values: debug, release")
-    endif()
-endfunction()
 
 function(_xrepo_package_name package)
     # For find_package(pkg) to work, we need to set variable <pkg>_DIR to the


### PR DESCRIPTION
原先的行为：如果当前项目 build type 为 debug，则第三方库的 build type 也是 debug。

该行为在日常开发中很可能并非大多数人想要的。通常 debug build 是用来调试当前项目的代码，仅切换当前项目的 build type 为 debug 导致所有第三方库需要重新编译代价过大。

之前有注意到这个问题，但因为我们使用 lua 脚本来指定包，观察到的现象是 [`--mode=debug` 没有生效](https://github.com/xmake-io/xmake/issues/2921)，正好是我们希望的行为所以没有细究。

这个 PR 会修改目前的行为，但若不做此改动，需要用户为每个包设置 `MODE release` 才能避免切换 build type 引起的第三方库重新编译。


去除 `_validate_mode` 是为了方便未来自动支持更多 mode。目前 `xrepo install --mode=xxx` 似乎只要 `xxx!=debug` 就作为 release 处理，不没有做校验。