### PR TITLE
set default visibility to private

### DIFF
--- a/xrepo.cmake
+++ b/xrepo.cmake
@@ -387,6 +387,8 @@ function(xrepo_target_packages target)
         set(_visibility "PUBLIC")
     elseif(ARG_INTERFACE)
         set(_visibility "INTERFACE")
+    else()
+        set(_visibility "PRIVATE")
     endif()
 
     foreach(package_name IN LISTS ARG_UNPARSED_ARGUMENTS)


### PR DESCRIPTION
使用 xrepo_target_packages 时如果没有指定visibility就会出错
官方例子里可以不指定，应该设置个默认值
https://github.com/xmake-io/xrepo-cmake/issues/30